### PR TITLE
Fix error, Won't boot image

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -1,6 +1,10 @@
 from Plugins.Plugin import PluginDescriptor
 
+print "[ServiceMP3] importing...."
+import servicemp3
+
 def autostart(reason, **kwargs):
+	print "[ServiceMP3] autostart...."
 	import servicemp3
 
 def Plugins(**kwargs):


### PR DESCRIPTION
As athoik wrote here .. Thank you
https://forums.openpli.org/topic/59035-problem-with-serviceapp/?view=findpost&p=868576

Fix error, Won't boot image

> PC: 7370b3c0
    00000000 00000001 00000000 00000001
    73714ecc 0097c730 00000b56 00000000
    00e01510 011bb150 00000013 769748f4
    00a358f8 7697494c 3a656a3d 7f96b888
    0097c730 73714ecc 00000001 7f96d0ec
    00aae698 0128ac00 0128ac00 ffffffff
    000012f4 7370b3a0 00000000 00000000
    7371c5b0 7f96bb58 7f96bc48 736fe010
Backtrace:
/usr/bin/enigma2(_Z17handleFatalSignaliP9siginfo_tPv) [0x45D6F8]
/usr/lib/enigma2/python/Plugins/SystemPlugins/ServiceMP3/servicemp3.so(n/a) [0x7370B3C2]
/usr/lib/enigma2/python/Plugins/SystemPlugins/ServiceMP3/servicemp3.so(n/a) [0x736FE010]
/lib/ld.so.1(n/a) [0x774FE96C]
-------FATAL SIGNAL