### PR TITLE
Move event evStart from NULL to READY to READY to PAUSED

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -1796,13 +1796,10 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 
 			switch(transition)
 			{
-				case GST_STATE_CHANGE_NULL_TO_READY:
-				{
-					m_event(this, evStart);
-				}	break;
 				case GST_STATE_CHANGE_READY_TO_PAUSED:
 				{
 					m_state = stRunning;
+					m_event(this, evStart);
 #if GST_VERSION_MAJOR >= 1
 					GValue result = { 0, };
 #endif
@@ -1947,9 +1944,6 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 						gst_object_unref(GST_OBJECT(videoSink));
 						videoSink = NULL;
 					}
-				}	break;
-				case GST_STATE_CHANGE_READY_TO_NULL:
-				{
 				}	break;
 			}
 			break;


### PR DESCRIPTION
Playback starts and seek functions start working only after READY to PAUSED, thefore move evStart to this state.
This for example fix getLength problem on playback start.

Also remove unused state transition checks.