### PR TITLE
Process tag at startup only. It solves multiple triggering id3coverart

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -2034,7 +2034,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 					break;
 				}
 				if (m_stream_tags)
-					gst_tag_list_free(m_stream_tags);
+					break;
 				m_stream_tags = result;
 			}
 


### PR DESCRIPTION
 reading and wrong displaying id3coverart in Mediaplayer