### PR TITLE
servicemp3: handle sVideoType info

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -1365,6 +1365,14 @@ int eServiceMP3::getInfo(int w)
 		tag = "has-crc";
 		break;
 	case sBuffer: return m_bufferInfo.bufferPercent;
+	case sVideoType:
+	{
+		if (!videoSink) return -1;
+		guint64 v = -1;
+		g_signal_emit_by_name(videoSink, "get-video-codec", &v);
+		return (int) v;
+		break;
+	}
 	default:
 		return resNA;
 	}


### PR DESCRIPTION
This commit handles the sVideoType information by using the new signal get-video-codec from dvbvideosink.
Please note that enigma2 should include the extra stream types now (eg on lib/python/Screens/ServiceInfo.py).

Depends on: https://github.com/OpenPLi/gst-plugin-dvbmediasink/pull/12