### PR TITLE
servicemp3: return sServiceref string without removing path

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -1402,12 +1402,7 @@ std::string eServiceMP3::getInfoString(int w)
 		case sProvider:
 			return "IPTV";
 		case sServiceref:
-		{
-			eServiceReference ref(m_ref);
-			ref.type = eServiceFactoryMP3::id;
-			ref.path.clear();
-			return ref.toString();
-		}
+			return m_ref.toString();
 		default:
 			break;
 		}


### PR DESCRIPTION
When sServiceref is requested on getInfoString it will return
the service without removing the path. Just like do in servicedvb.