### PR TITLE
servicemp3: add handler for sSID on getInfo

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -1379,6 +1379,7 @@ int eServiceMP3::getInfo(int w)
 		return (int) v;
 		break;
 	}
+	case sSID: return m_ref.getData(1);
 	default:
 		return resNA;
 	}


### PR DESCRIPTION
This commit will return the SID stored on eServiceReference.data[1]
when sSID information requested.

Related: https://devtools.openpli.org/issues/216