### PR TITLE
servicemp3: fix autoaudio selection

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -432,6 +432,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	m_use_prefillbuffer = false;
 	m_paused = false;
 	m_seek_paused = false;
+	m_autoaudio = true;
 	m_cuesheet_loaded = false; /* cuesheet CVR */
 #if GST_VERSION_MAJOR >= 1
 	m_use_chapter_entries = false; /* TOC chapter support CVR */
@@ -1906,7 +1907,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
 				{
 					m_paused = false;
-					if (m_currentAudioStream < 0)
+					if (m_autoaudio)
 					{
 						unsigned int autoaudio = 0;
 						int autoaudio_level = 5;
@@ -1943,6 +1944,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 
 						if (autoaudio)
 							selectTrack(autoaudio);
+						m_autoaudio = false;
 					}
 					m_event((iPlayableService*)this, evGstreamerPlayStarted);
 				}	break;

--- a/servicemp3/servicemp3.h
+++ b/servicemp3/servicemp3.h
@@ -308,6 +308,7 @@ private:
 	bool m_use_prefillbuffer;
 	bool m_paused;
 	bool m_seek_paused;
+	bool m_autoaudio;
 	/* cuesheet load check */
 	bool m_cuesheet_loaded;
 	/* servicemMP3 chapter TOC support CVR */


### PR DESCRIPTION
When servicemp3 goes on state transition NULL -> READY the getCurrentTrack function called
and m_currentAudioStream changes to 0.

So later on state transition PAUSED -> PLAYING the check for autoaudio is never executed,
since we expect m_currentAudioStream to be -1.

Instead of using m_currentAudioStream variable use new variable m_autoaudio that will allow
autoaudio selection to performed only once.
[eServiceMP3] getCurrentTrack called with m_currentAudioStream == -1