### PR TITLE
servicemp3: always handle sServiceref on getInfoString

### DIFF
--- a/servicemp3/servicemp3.cpp
+++ b/servicemp3/servicemp3.cpp
@@ -1398,17 +1398,14 @@ int eServiceMP3::getInfo(int w)
 
 std::string eServiceMP3::getInfoString(int w)
 {
-	if ( m_sourceinfo.is_streaming )
+	switch (w)
 	{
-		switch (w)
-		{
-		case sProvider:
-			return "IPTV";
-		case sServiceref:
-			return m_ref.toString();
-		default:
-			break;
-		}
+	case sProvider:
+		return m_sourceinfo.is_streaming ? "IPTV" : "FILE";
+	case sServiceref:
+		return m_ref.toString();
+	default:
+		break;
 	}
 
 	if ( !m_stream_tags && w < sUser && w > 26 )


### PR DESCRIPTION
When sServiceref was used for local files, getInfoString returns an empty string
making checks expecting data returned from getInfoString to fail.

This commit will handle sServiceref for all media types.
Additionally, this commit will return "FILE" as a provider for local files.