### PR TITLE
configure.ac: Remove configure option --with-gstversion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,11 +10,7 @@ AX_PYTHON_DEVEL
 AC_LANG(C++)
 
 PKG_CHECK_MODULES(ENIGMA2, enigma2)
-AC_ARG_WITH(gstversion,
-	AS_HELP_STRING([--with-gstversion],[use gstreamer version (major.minor)]),
-	[GST_MAJORMINOR=$withval],[GST_MAJORMINOR=1.0])
-
-PKG_CHECK_MODULES(GSTREAMER, gstreamer-$GST_MAJORMINOR gstreamer-pbutils-$GST_MAJORMINOR)
+PKG_CHECK_MODULES(GSTREAMER, gstreamer-1.0 gstreamer-pbutils-1.0)
 
 AX_CXX_COMPILE_STDCXX_17([ext],[mandatory])
 


### PR DESCRIPTION
There's only one, 1.0.

Macro GST_MAJORMINOR already deleled with commit:
https://github.com/OpenPLi/servicemp3/commit/9956c7518d3d37c9170fb7a975f7ac846d9fb67a